### PR TITLE
create producer uuid, use as Kafka message key

### DIFF
--- a/websocket_client_example.py
+++ b/websocket_client_example.py
@@ -1,9 +1,12 @@
+import uuid
 import websocket
 
 from myproducer import producer
 
+producer_uuid = uuid.uuid4()
+
 def on_message(ws, message):
-    future = producer.send('gdax', message.encode('utf-8'))
+    future = producer.send('gdax', message.encode('utf-8'), producer_uuid.bytes)
     result = future.get(timeout=10)
 
 def on_error(ws, error):

--- a/websockets_example.py
+++ b/websockets_example.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
 
+import uuid
 import asyncio
 import websockets
 
 from myproducer import producer
 
+producer_uuid = uuid.uuid4()
+
 async def handler(websocket):
     while True:
         msg = await websocket.recv()
-        future = producer.send('gdax', msg.encode('utf-8'))
+        future = producer.send('gdax', msg.encode('utf-8'), producer_uuid.bytes)
         result = future.get(timeout=10)
 
 async def main():

--- a/ws4py_example.py
+++ b/ws4py_example.py
@@ -1,6 +1,10 @@
+import uuid
+
 from ws4py.client.threadedclient import WebSocketClient
 
 from myproducer import producer
+
+producer_uuid = uuid.uuid4()
 
 class DummyClient(WebSocketClient):
     def opened(self):
@@ -14,7 +18,7 @@ class DummyClient(WebSocketClient):
         print("Closed down", code, reason)
 
     def received_message(self, m):
-        future = producer.send('gdax', str(m).encode('utf-8'))
+        future = producer.send('gdax', str(m).encode('utf-8'), producer_uuid.bytes)
         result = future.get(timeout=10)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Separates producer messages into partitions. This is required for redundancy and auditing data coming from an exchange.