### PR TITLE
producer uuid field as bytes

### DIFF
--- a/myproducer.py
+++ b/myproducer.py
@@ -1,13 +1,14 @@
 import os
 import sys
 import json
+import uuid
 from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
 
 bootstrap_servers = os.environ['KAFKA_BOOTSTRAP_SERVERS']
 schema_registry_url = os.environ['KAFKA_SCHEMA_REGISTRY_URL']
 
-key_schema = avro.loads(json.dumps({'type': 'string'}))
+key_schema = avro.loads(json.dumps({'type': 'bytes'}))
 value_schema = avro.load('websocket-raw.avsc')
 
 producer = AvroProducer({
@@ -20,3 +21,5 @@ producer = AvroProducer({
     default_key_schema=key_schema,
     default_value_schema=value_schema,
 )
+
+producer.uuid = uuid.uuid4()

--- a/websocket-raw.avsc
+++ b/websocket-raw.avsc
@@ -9,7 +9,7 @@
       },
       {
         "name": "producerUUID",
-        "type": "string"
+        "type": "bytes"
       },
       {
         "name": "data",

--- a/websocket_client_example.py
+++ b/websocket_client_example.py
@@ -1,4 +1,3 @@
-import uuid
 import logging
 from datetime import datetime
 import websocket
@@ -7,14 +6,12 @@ from myproducer import producer
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-producer_uuid = uuid.uuid4()
-
 def on_message(ws, message):
-    value = {'timestamp': str(datetime.utcnow()), 'producerUUID': str(producer_uuid), 'data': message}
+    value = {'timestamp': str(datetime.utcnow()), 'producerUUID': producer_uuid.bytes, 'data': message}
     producer.produce(
         topic='websocket_client-gdax',
         value=value,
-        key=str(producer_uuid),
+        key=producer.uuid.bytes,
     )
     producer.poll(0)
 

--- a/websockets_example.py
+++ b/websockets_example.py
@@ -7,16 +7,14 @@ import websockets
 
 from myproducer import producer
 
-producer_uuid = uuid.uuid4()
-
 async def handler(websocket):
     while True:
         msg = await websocket.recv()
-        value = {'timestamp': str(datetime.utcnow()), 'producerUUID': str(producer_uuid), 'data': msg}
+        value = {'timestamp': str(datetime.utcnow()), 'producerUUID': producer.uuid.bytes, 'data': msg}
         producer.produce(
             topic='websockets-gdax',
             value=value,
-            key=str(producer_uuid),
+            key=producer.uuid.bytes,
         )
         producer.poll(0)
 

--- a/ws4py_example.py
+++ b/ws4py_example.py
@@ -8,8 +8,6 @@ from myproducer import producer
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-producer_uuid = uuid.uuid4()
-
 class DummyClient(WebSocketClient):
     def opened(self):
         def data_provider():
@@ -22,11 +20,11 @@ class DummyClient(WebSocketClient):
         logging.warning("Closed down", code, reason)
 
     def received_message(self, m):
-        value = {'timestamp': str(datetime.utcnow()), 'producerUUID': str(producer_uuid), 'data': str(m)}
+        value = {'timestamp': str(datetime.utcnow()), 'producerUUID': producer.uuid.bytes, 'data': str(m)}
         producer.produce(
             topic='ws4py-gdax',
             value=value,
-            key=str(producer_uuid),
+            key=producer.uuid.bytes,
         )
         producer.poll(0)
 


### PR DESCRIPTION
* Reduces data size by approximately 20%.
* Comparing producer ids visually is still possible.