### PR TITLE
[websocket] change raw timestamp field to time_collected

### DIFF
--- a/gdax.py
+++ b/gdax.py
@@ -19,6 +19,6 @@ subscription_message = {
 
 def create_raw(dt, producer_uuid, data):
     data_dict = json.loads(data)
-    extra = {'timestamp': dt.isoformat(), 'producerUUID': producer_uuid.bytes}
+    extra = {'time_collected': dt.isoformat(), 'producerUUID': producer_uuid.bytes}
     raw = {**extra, **data_dict}
     return raw

--- a/schemas/websocket-raw.avsc
+++ b/schemas/websocket-raw.avsc
@@ -1,10 +1,10 @@
 {
     "type": "record",
     "name": "raw",
-    "namespace": "gdax",
+    "namespace": "gdax.websocket",
     "fields": [
       {
-        "name": "timestamp",
+        "name": "time_collected",
         "type": "string"
       },
       {


### PR DESCRIPTION
To match polling schemas and to differentiate between timestamps given from APIs.